### PR TITLE
Add bin symlink support and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ sudo apt install build-essential cmake git curl jq nvidia-cuda-toolkit
 
 # 4. Run initial build
 ./autodevops.bash --now
+# 5. Use binaries from ./bin (created automatically)
+ls -l bin
 ```
 
 ## 📋 System Components
@@ -57,10 +59,11 @@ sudo apt install build-essential cmake git curl jq nvidia-cuda-toolkit
 6. Optimizes build for your specific GPU
 7. Creates symlink to current build
 8. Updates version tracking
+9. Links latest binaries into `./bin`
 
 ### 2. `loadmodel.bash` - Model Server Launcher
 
-**Purpose**: Provides a unified interface for starting llama-server in different modes.
+**Purpose**: Provides a unified interface for starting llama-server in different modes. The script automatically uses the binaries in `./bin` created by `autodevops.bash`.
 
 **Usage Examples**:
 ```bash
@@ -112,6 +115,9 @@ $HOME/
 │   └── llama-cpp-b5748/
 ├── llama-current/               # Symlink to current build
 │   └── build/bin/llama-server   # Current server binary
+├── llama-cpp-autodeploy/
+│   ├── bin/                     # Symlinks to latest binaries
+│   └── llama-cpp-latest -> ../llama-builds/llama-cpp-bXXXX/
 ├── .llama-version              # Current version tracking
 ├── autodevops.log              # Main operation log
 └── autodevops-cron.log         # Cron execution log
@@ -178,7 +184,7 @@ tail -f $HOME/autodevops.log
 cat $HOME/.llama-version
 
 # Test current build
-$HOME/llama-current/build/bin/llama-server --help
+./bin/llama-server --help
 ```
 
 ## 🚨 Troubleshooting

--- a/autodevops.bash
+++ b/autodevops.bash
@@ -14,6 +14,10 @@ CURRENT_DIR="$HOME/llama-current"
 LOG_FILE="$HOME/autodevops.log"
 VERSION_FILE="$HOME/.llama-version"
 
+# Directory of this script and local bin for symlinks
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_BIN="$SCRIPT_DIR/bin"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -183,6 +187,16 @@ build_llama_cpp() {
 
     ln -sf "$build_path" "$CURRENT_DIR"
     log "Updated current build symlink"
+
+    # Update local symlinks in repository
+    mkdir -p "$LOCAL_BIN"
+    ln -sfn "$build_path" "$SCRIPT_DIR/llama-cpp-latest"
+    for f in "$build_path"/build/bin/*; do
+        if [[ -f "$f" ]]; then
+            ln -sfn "$f" "$LOCAL_BIN/$(basename "$f")"
+        fi
+    done
+    log "Updated local repository bin symlinks"
 
     # Update version file
     echo "$version" > "$VERSION_FILE"

--- a/loadmodel.bash
+++ b/loadmodel.bash
@@ -12,6 +12,9 @@ DEFAULT_CONTEXT_SIZE="2048"
 DEFAULT_THREADS=$(nproc)
 DEFAULT_GPU_LAYERS="999"  # Auto-detect max layers
 
+# Directory of this script and local bin with symlinked binaries
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -71,6 +74,8 @@ check_llama_cpp() {
 
     # Check multiple possible locations
     local possible_paths=(
+        "$SCRIPT_DIR/bin/llama-server"
+        "$SCRIPT_DIR/llama-cpp-latest/build/bin/llama-server"
         "$HOME/llama-current/build/bin/llama-server"
         "$HOME/llama-current/llama-server"
         "./llama-server"


### PR DESCRIPTION
## Summary
- symlink build directory binaries into repo `bin/`
- update `loadmodel.bash` search paths
- document new usage in README
- add placeholder file for `bin/`

## Testing
- `bash -n autodevops.bash`
- `bash -n loadmodel.bash`


------
https://chatgpt.com/codex/tasks/task_e_685c973657ec8330ba5b6bbb7e08b160