### PR TITLE
Add ignore rules for generated binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+llama-cpp-latest
+bin/*
+!bin/.gitkeep


### PR DESCRIPTION
## Summary
- ignore generated symlink `llama-cpp-latest`
- exclude everything in `bin/` except `.gitkeep`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ca100d35083308302893a992eccc6