### PR TITLE
Fix README trailing fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,4 +307,4 @@ To extend the system:
 4. Test on clean Debian system
 5. Submit improvements
 
-The modular design allows easy customization of individual components without affecting the overall automation flow.# llama-cpp-autodeploy
+The modular design allows easy customization of individual components without affecting the overall automation flow.


### PR DESCRIPTION
## Summary
- fix extraneous `# llama-cpp-autodeploy` fragment at the end of README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ca101e5608330ac6f40f728db184b