### PR TITLE
Add HF token support and local build dirs

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,3 @@
+# Local environment configuration
+# Provide your Hugging Face token here if you need to access private models
+HF_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Ignore user-specific environment
+.env
+
+# Build artifacts and downloads
+bin/
+models/
+llama-builds/
+llama-current/
+llama-cpp-latest
+
+# Logs and version tracking
+*.log
+.llama-version
+
+# Allow keeping placeholder files
+!bin/.gitkeep
+!models/.gitignore
+!llama-builds/.gitignore
+!llama-current/.gitignore

--- a/autodevops.bash
+++ b/autodevops.bash
@@ -9,10 +9,10 @@ set -euo pipefail
 # Configuration
 REPO_URL="https://github.com/ggml-org/llama.cpp"
 API_URL="https://api.github.com/repos/ggml-org/llama.cpp/releases/latest"
-BUILD_DIR="$HOME/llama-builds"
-CURRENT_DIR="$HOME/llama-current"
-LOG_FILE="$HOME/autodevops.log"
-VERSION_FILE="$HOME/.llama-version"
+BUILD_DIR="$SCRIPT_DIR/llama-builds"
+CURRENT_DIR="$SCRIPT_DIR/llama-current"
+LOG_FILE="$SCRIPT_DIR/autodevops.log"
+VERSION_FILE="$SCRIPT_DIR/.llama-version"
 
 # Directory of this script and local bin for symlinks
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/llama-builds/.gitignore
+++ b/llama-builds/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore

--- a/llama-current/.gitignore
+++ b/llama-current/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore

--- a/models/.gitignore
+++ b/models/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore


### PR DESCRIPTION
## Summary
- store builds and models in repo directories
- ignore build artifacts in .gitignore
- allow `loadmodel.bash` to read `.env` or `.env.local` for `HF_TOKEN`
- use token when downloading models
- update README with new directory layout and environment info

## Testing
- `bash -n autodevops.bash`
- `bash -n loadmodel.bash`
- `bash loadmodel.bash --help`

------
https://chatgpt.com/codex/tasks/task_e_685ca85725b0833094cbdfd0f4f16455